### PR TITLE
Bugfix/Downgrade rxjs 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "@types/node": "^8.0.53"
   },
   "dependencies": {
-    "rxjs": "^6.1.0"
+    "rxjs": "5.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "@types/node": "^8.0.53"
   },
   "dependencies": {
-    "rxjs": "5.5.1"
+    "rxjs": "5.5.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,12 +6,12 @@
   version "8.10.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.14.tgz#a24767cfa22023f1bf7e751c0ead56a14c07ed45"
 
-rxjs@5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.1.tgz#ef980a6ad7438c74e3b0f0d1e6f1493e385997fd"
+rxjs@5.5.10:
+  version "5.5.10"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
   dependencies:
-    symbol-observable "^1.0.1"
+    symbol-observable "1.0.1"
 
-symbol-observable@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,12 +6,12 @@
   version "8.10.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.14.tgz#a24767cfa22023f1bf7e751c0ead56a14c07ed45"
 
-rxjs@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.1.0.tgz#833447de4e4f6427b9cec3e5eb9f56415cd28315"
+rxjs@5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.1.tgz#ef980a6ad7438c74e3b0f0d1e6f1493e385997fd"
   dependencies:
-    tslib "^1.9.0"
+    symbol-observable "^1.0.1"
 
-tslib@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+symbol-observable@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"


### PR DESCRIPTION
@bryphe seems I was too hasty in upgrading `rxjs` its been a fairly big release and they've seem to have worked quite hard to minimise the impact on users but basically the `oni-types` package has to have matching type definitions as `oni-core` so package versions seem to need to be in sync

I actually tried upgrading our `rxjs` in core to 6 as there's a compatibility plugin as well as a tslint code mod all of which ran well with only a few remaining warnings the main issue though is that `redux-observable` isn't ready for it yet an are planning a 1.0.0 release.

Think there might need to be a PR in core when every thing is settled to migrate this and oni-core (down the line)

I've actually tested this change by installing my branch of this package locally and building it seems the primary issue was the devDependency rather than dependency listing apologies for the up and down